### PR TITLE
Update Readme. Pump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 This gem contains common libraries which shared between projects used in TINYpulse.
 
+Currently, we have:
+
+1. Timezone helpers
+2. Asset loader
+3. File storage
+
 ## Rails versions
 
 From v0.2.0 `tp_common` support only rails > 4. Mostly on ActiveSupport DateTime functions and `Rails.config_for` method.

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    tp_common (0.3.0)
+    tp_common (0.4.0)
       activesupport (>= 4.2.0, <= 5.2)
       aws-sdk-s3 (~> 1.19)
       fog-aws (~> 2.0)
@@ -52,7 +52,7 @@ GEM
     arel (6.0.4)
     aws-eventstream (1.0.1)
     aws-partitions (1.111.0)
-    aws-sdk-core (3.37.0)
+    aws-sdk-core (3.38.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)

--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    tp_common (0.3.0)
+    tp_common (0.4.0)
       activesupport (>= 4.2.0, <= 5.2)
       aws-sdk-s3 (~> 1.19)
       fog-aws (~> 2.0)
@@ -55,7 +55,7 @@ GEM
     arel (7.1.4)
     aws-eventstream (1.0.1)
     aws-partitions (1.111.0)
-    aws-sdk-core (3.37.0)
+    aws-sdk-core (3.38.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)

--- a/lib/tp_common/version.rb
+++ b/lib/tp_common/version.rb
@@ -1,3 +1,3 @@
 module TpCommon
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
@harley @T-800 @haodoan90 

I'm going to pump to `v0.4.0` and upgrade on Engage to extract FileStorge. 
Please let me know if changes on `v0.3.0` is not ready to apply. 